### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Shreyansh88930/cryptolib-ci-demo/security/code-scanning/3](https://github.com/Shreyansh88930/cryptolib-ci-demo/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow uses the `Klemensas/action-autotag@stable` action, which likely requires write access to `contents` to create tags, we will set `contents: write` as the minimum required permission. This ensures the workflow adheres to the principle of least privilege while still functioning correctly.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This is appropriate since the workflow contains only one job (`tag`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
